### PR TITLE
Small typo fix in properties of cross product

### DIFF
--- a/src/S-9-4-Cross-Product.mbx
+++ b/src/S-9-4-Cross-Product.mbx
@@ -384,7 +384,7 @@
 
         <li>
           <p>
-            <m>(c\vu)\times \vw = c(\vu \times \vw) = \vu \times (c\vv)</m>
+            <m>(c\vu)\times \vw = c(\vu \times \vw) = \vu \times (c\vw)</m>
           </p>
         </li>
 


### PR DESCRIPTION
In section 9.4 there is a small typo in the properties of the cross product where a \vv should have been a \vw.